### PR TITLE
Add repository charter stub

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,8 @@
+# Charter
+
+This repository's charter — what belongs here and what doesn't — is governed
+centrally in `speckit`, the single source of truth:
+
+https://github.com/Odyssey-Classic/speckit/blob/main/charters/server.md
+
+The link tracks `main`, so it always reflects the current charter.


### PR DESCRIPTION
Adds a compact `CHARTER.md` pointing to this repository's authoritative charter, governed centrally in `speckit`: https://github.com/Odyssey-Classic/speckit/blob/main/charters/server.md

Part of the Repository Charters rollout (Phase 2). The charter is the single source of truth; this stub is a pure pointer (no restated attributes) and tracks `speckit main`, so it always reflects the current charter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NhEZKGs9z2kxvDpBToeP7